### PR TITLE
Output resources as unstructured instead of a native go type

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	boilerplate := flag.String("go-header-file", "", "File containing boilerplate header text. The string YEAR will be replaced with the current 4-digit year.")
 	crdPackages := flag.String("crd-packages", "", "Comma separated list of packages containing CRD definitions")
 	onlyMeta := flag.Bool("only-meta", false, "Generate only metadata, don't go to spec")
+	unstructured := flag.Bool("unstructured", false, "Generate objects of type unstructured.Unstructured{} instead of the underlying types")
 	flag.Parse()
 	if *pkg == "" {
 		fail("Missing required flag -package")
@@ -29,7 +30,7 @@ func main() {
 		fail("Missing required flag -src")
 	}
 
-	objs := rev.ReadInput(*src, *crdPackages)
+	objs := rev.ReadInput(*src, *crdPackages, *unstructured)
 	imports, goObjects := rev.ProcessObjects(objs, *kubermaticInterfaces, *onlyMeta)
 	rev.Print(*pkg, *boilerplate, imports, goObjects, *kubermaticInterfaces)
 }

--- a/pkg/in_out.go
+++ b/pkg/in_out.go
@@ -260,7 +260,7 @@ func updateCRDsScheme(crdPackages string) error {
 	return nil
 }
 
-func ReadInput(path, crdPackages string) (objs []object) {
+func ReadInput(path, crdPackages string, unstructured bool) (objs []object) {
 	d := read(path)
 	err := updateCRDsScheme(crdPackages)
 	// TODO: do this dynamically
@@ -270,10 +270,17 @@ func ReadInput(path, crdPackages string) (objs []object) {
 	checkFatal(err)
 	codecs := serializer.NewCodecFactory(scheme.Scheme)
 	for _, data := range d {
-		objs = append(objs, object{
-			rt: getRuntimeObject(data, codecs),
-			un: getUnstructuredObject(data),
-		})
+		if unstructured {
+			objs = append(objs, object{
+				rt: getUnstructuredObject(data),
+				un: getUnstructuredObject(data),
+			})
+		} else {
+			objs = append(objs, object{
+				rt: getRuntimeObject(data, codecs),
+				un: getUnstructuredObject(data),
+			})
+		}
 	}
 	return
 }


### PR DESCRIPTION
This can be useful when dealing with resources programmatically but without the desire to import scheme registrations as these can drag many unrelated transitive deps. Rarely third party kubernetes operators have API packages separate from the implementation which means for a few CRD definitions in go, you get various incompatible controller-runtimes versions as a bonus and a dependency hell to resolve.